### PR TITLE
Feature/enhancement

### DIFF
--- a/Assets/Tools/Editor/MyParticleEffectUI.cs
+++ b/Assets/Tools/Editor/MyParticleEffectUI.cs
@@ -13,15 +13,17 @@ public class MyParticleEffectUI : Editor {
     {
         ParticleEffectScript particleEffectScript = (ParticleEffectScript)target;
 
-        m_Label[0] = GetParticleEffectData.GetGetRuntimeMemorySizeStr(particleEffectScript.gameObject);
+        int index = 0;
+        m_Label[index] = GetParticleEffectData.GetGetRuntimeMemorySizeStr(particleEffectScript.gameObject);
+        m_Label[++index] = GetParticleEffectData.GetParticleSystemCount(particleEffectScript.gameObject);
 
         if (EditorApplication.isPlaying)
         {
-            m_Label[1] = GetParticleEffectData.GetOnlyParticleEffecDrawCallStr();
-            m_Label[2] = GetParticleEffectData.GetParticleCountStr(particleEffectScript);
-            m_Label[3] = GetParticleEffectData.GetPixDrawAverageStr(particleEffectScript);
-            m_Label[4] = GetParticleEffectData.GetPixActualDrawAverageStr(particleEffectScript);
-            m_Label[5] = GetParticleEffectData.GetPixRateStr(particleEffectScript);
+            m_Label[++index] = GetParticleEffectData.GetOnlyParticleEffecDrawCallStr();
+            m_Label[++index] = GetParticleEffectData.GetParticleCountStr(particleEffectScript);
+            m_Label[++index] = GetParticleEffectData.GetPixDrawAverageStr(particleEffectScript);
+            m_Label[++index] = GetParticleEffectData.GetPixActualDrawAverageStr(particleEffectScript);
+            m_Label[++index] = GetParticleEffectData.GetPixRateStr(particleEffectScript);
         }
 
         ShowUI(); 

--- a/Assets/Tools/Editor/TestParticleEffect.cs
+++ b/Assets/Tools/Editor/TestParticleEffect.cs
@@ -1,14 +1,14 @@
-﻿using System.Collections.Generic;
-using UnityEditor;
+﻿using UnityEditor;
 using UnityEngine;
 
-public class TestParticleEffe{
-
+[InitializeOnLoad]
+public static class TestParticleEffect
+{
     [MenuItem("GameObject/特效/测试", false, 11)]
-    static void Test()
+    private static void Test()
     {
-        GameObject go = Selection.activeGameObject;
-        List<ParticleSystemRenderer> particleSystemRenderer = GetParticleEffectData.GetComponentByType<ParticleSystemRenderer>(go);
+        var go = Selection.activeGameObject;
+        var particleSystemRenderer = GetParticleEffectData.GetComponentByType<ParticleSystemRenderer>(go);
 
         if (particleSystemRenderer.Count == 0)
         {
@@ -16,13 +16,44 @@ public class TestParticleEffe{
             return;
         }
 
-        List<ParticleEffectScript> particleEffectScript = GetParticleEffectData.GetComponentByType<ParticleEffectScript>(go);
-
-        if (particleEffectScript.Count == 0)
-        {
-            go.AddComponent<ParticleEffectScript>();
-        }
-
+        EditorPrefs.SetBool(RequestTestKey, true);
         EditorApplication.isPlaying = true;
     }
+
+    static TestParticleEffect()
+    {
+        EditorApplication.update += Update;
+        EditorApplication.playmodeStateChanged += PlaymodeStateChanged;
+    }
+
+    private static void Update()
+    {
+        if (EditorPrefs.HasKey(RequestTestKey) && !_hasPlayed &&
+            EditorApplication.isPlaying &&
+            EditorApplication.isPlayingOrWillChangePlaymode)
+        {
+            EditorPrefs.DeleteKey(RequestTestKey);
+            _hasPlayed = true;
+
+            var go = Selection.activeGameObject;
+
+            var particleEffectScript = GetParticleEffectData.GetComponentByType<ParticleEffectScript>(go);
+
+            if (particleEffectScript.Count == 0)
+            {
+                go.AddComponent<ParticleEffectScript>();
+            }
+        }
+    }
+
+    private static void PlaymodeStateChanged()
+    {
+        if (!EditorApplication.isPlaying)
+        {
+            _hasPlayed = false;
+        }
+    }
+
+    private const string RequestTestKey = "TestParticleEffectRquestTest";
+    private static bool _hasPlayed;
 }

--- a/Assets/Tools/Scripts/CSVEffectEvlaHelper.cs
+++ b/Assets/Tools/Scripts/CSVEffectEvlaHelper.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if UNITY_EDITOR
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -114,3 +115,4 @@ public class CSVEffectEvlaHelper {
         
     }
 }
+#endif

--- a/Assets/Tools/Scripts/EffectEvla.cs
+++ b/Assets/Tools/Scripts/EffectEvla.cs
@@ -8,7 +8,7 @@ public class EffectEvla {
     SingleEffectEvla singleEffectEvla;
     public float time = 0;
 
-    public void Init(Camera camera)
+    public virtual void Init(Camera camera)
     {
         SetCamera(camera);
     }

--- a/Assets/Tools/Scripts/EffectEvla.cs
+++ b/Assets/Tools/Scripts/EffectEvla.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if UNITY_EDITOR
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -121,3 +122,4 @@ public class EffectEvla {
     }
     #endregion
 }
+#endif

--- a/Assets/Tools/Scripts/EffectEvla2.cs
+++ b/Assets/Tools/Scripts/EffectEvla2.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if UNITY_EDITOR
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -318,3 +319,4 @@ public class SingleEffectEvlaComparer2 : IComparer
         return 0;
     }
 }
+#endif

--- a/Assets/Tools/Scripts/EffectEvla2.cs
+++ b/Assets/Tools/Scripts/EffectEvla2.cs
@@ -39,7 +39,7 @@ public class EffectEvla2 : EffectEvla
         this.Init(Camera.main);
     }
 
-    public void Init(Camera camera)
+    public override void Init(Camera camera)
     {
         CSVEffectEvlaHelper.GetInstance();
 
@@ -95,7 +95,7 @@ public class EffectEvla2 : EffectEvla
         }
         singleEffectEvlas = null;
 
-        CSVEffectEvlaHelper cSVEffectEvlaHelper = CSVEffectEvlaHelper.GetInstance();
+        CSVEffectEvlaHelper.GetInstance();
         CSVEffectEvlaHelper.DestroyInstance();
     }
     

--- a/Assets/Tools/Scripts/EffectEvlaData2.cs
+++ b/Assets/Tools/Scripts/EffectEvlaData2.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if UNITY_EDITOR
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -78,3 +79,4 @@ public class EffectEvlaData2
         return "带宽：" + this.tape;
     }
 }
+#endif

--- a/Assets/Tools/Scripts/GetParticleEffectData.cs
+++ b/Assets/Tools/Scripts/GetParticleEffectData.cs
@@ -10,9 +10,10 @@ public class GetParticleEffectData {
 
     static int m_MaxDrawCall = 0;
 
-    public static string GetRuntimeMemorySize(GameObject go)
+    public static string GetRuntimeMemorySize(GameObject go, out int textureCount)
     {
         var textures = new List<Texture>();
+        textureCount = 0;
         long sumSize = 0;
 
         List<ParticleSystemRenderer> meshRendererlist = GetComponentByType<ParticleSystemRenderer>(go);
@@ -25,6 +26,7 @@ public class GetParticleEffectData {
                 if (texture && !textures.Contains(texture))
                 {
                     textures.Add(texture);
+                    textureCount++;
                     sumSize = sumSize + GetStorageMemorySize(texture);
                 }
             }
@@ -67,7 +69,9 @@ public class GetParticleEffectData {
 
     public static string GetGetRuntimeMemorySizeStr(GameObject go)
     {
-        return string.Format("贴图所占用的内存：{0}   建议：<100 KB", GetRuntimeMemorySize(go));
+        int textureCount;
+        string memorySize = GetRuntimeMemorySize(go, out textureCount);
+        return string.Format("贴图所占用的内存：{0}   建议：<100 KB\n贴图数量：{1} 建议：<5", memorySize, textureCount);
     }
 
     public static string GetParticleSystemCount(GameObject go)

--- a/Assets/Tools/Scripts/GetParticleEffectData.cs
+++ b/Assets/Tools/Scripts/GetParticleEffectData.cs
@@ -22,11 +22,24 @@ public class GetParticleEffectData {
                 Texture texture = item.sharedMaterial.mainTexture;
                 if (texture)
                 {
-                    sumSize = sumSize + Profiler.GetRuntimeMemorySizeLong(texture);
+                    sumSize = sumSize + GetStorageMemorySize(texture);
                 }
             }
         }
         return EditorUtility.FormatBytes(sumSize);
+    }
+
+    private static int GetStorageMemorySize(Texture texture)
+    {
+        return (int)InvokeInternalAPI("UnityEditor.TextureUtil", "GetStorageMemorySize", texture);
+    }
+
+    private static object InvokeInternalAPI(string type, string method, params object[] parameters)
+    {
+        var assembly = typeof(AssetDatabase).Assembly;
+        var custom = assembly.GetType(type);
+        var methodInfo = custom.GetMethod(method, BindingFlags.Public | BindingFlags.Static);
+        return methodInfo != null ? methodInfo.Invoke(null, parameters) : 0;
     }
 
     //获取物体对应的组件，包括子对象
@@ -45,7 +58,7 @@ public class GetParticleEffectData {
                     list.Add((T)component);
                 }
             }
-        } 
+        }
         return list;
     }
 

--- a/Assets/Tools/Scripts/GetParticleEffectData.cs
+++ b/Assets/Tools/Scripts/GetParticleEffectData.cs
@@ -227,9 +227,9 @@ public class GetParticleEffectData {
         {
             text += "\n勾选了 Limit Velocity Over Lifetime";
         }
-        if (particleSystem.main.simulationSpace != 0)
+        if (particleSystem.main.simulationSpace != ParticleSystemSimulationSpace.Local)
         {
-            text += "\nSimulationSpace 不等于0";
+            text += "\nSimulationSpace 不等于 Local";
         }
         if (particleSystem.main.gravityModifierMultiplier != 0)
         {

--- a/Assets/Tools/Scripts/GetParticleEffectData.cs
+++ b/Assets/Tools/Scripts/GetParticleEffectData.cs
@@ -170,7 +170,9 @@ public class GetParticleEffectData {
             {
                 case ParticleSystemShapeType.Cone:
                 case ParticleSystemShapeType.ConeVolume:
+#if UNITY_2017_1_OR_NEWER
                 case ParticleSystemShapeType.Donut:
+#endif
                 case ParticleSystemShapeType.Circle:
                     if(particleSystem.shape.arcMode != ParticleSystemShapeMultiModeValue.Random)
                     {

--- a/Assets/Tools/Scripts/GetParticleEffectData.cs
+++ b/Assets/Tools/Scripts/GetParticleEffectData.cs
@@ -12,6 +12,7 @@ public class GetParticleEffectData {
 
     public static string GetRuntimeMemorySize(GameObject go)
     {
+        var textures = new List<Texture>();
         long sumSize = 0;
 
         List<ParticleSystemRenderer> meshRendererlist = GetComponentByType<ParticleSystemRenderer>(go);
@@ -21,8 +22,9 @@ public class GetParticleEffectData {
             if (item.sharedMaterial)
             {
                 Texture texture = item.sharedMaterial.mainTexture;
-                if (texture)
+                if (texture && !textures.Contains(texture))
                 {
+                    textures.Add(texture);
                     sumSize = sumSize + GetStorageMemorySize(texture);
                 }
             }

--- a/Assets/Tools/Scripts/GetParticleEffectData.cs
+++ b/Assets/Tools/Scripts/GetParticleEffectData.cs
@@ -227,11 +227,11 @@ public class GetParticleEffectData {
         {
             text += "\n勾选了 Limit Velocity Over Lifetime";
         }
-        if (particleSystem.simulationSpace != 0)
+        if (particleSystem.main.simulationSpace != 0)
         {
             text += "\nSimulationSpace 不等于0";
         }
-        if (particleSystem.gravityModifier != 0)
+        if (particleSystem.main.gravityModifierMultiplier != 0)
         {
             text += "\nGravityModifier 不等于0";
         }

--- a/Assets/Tools/Scripts/GetParticleEffectData.cs
+++ b/Assets/Tools/Scripts/GetParticleEffectData.cs
@@ -68,6 +68,12 @@ public class GetParticleEffectData {
         return string.Format("贴图所占用的内存：{0}   建议：<100 KB", GetRuntimeMemorySize(go));
     }
 
+    public static string GetParticleSystemCount(GameObject go)
+    {
+        var particleSystems = go.GetComponentsInChildren<ParticleSystem>(true);
+        return string.Format("特效中所有粒子系统组件数量：{0}     建议：<5", particleSystems.Length);
+    }
+
     public static int GetOnlyParticleEffecDrawCall()
     {
         //如果场景不只有特效这个值就不一定对

--- a/Assets/Tools/Scripts/GetParticleEffectData.cs
+++ b/Assets/Tools/Scripts/GetParticleEffectData.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿#if UNITY_EDITOR
+using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using UnityEditor;
@@ -272,4 +273,4 @@ public class GetParticleEffectData {
         return false; //只能默认返回false了
     }
 }
-
+#endif

--- a/Assets/Tools/Scripts/GetParticleEffectData.cs
+++ b/Assets/Tools/Scripts/GetParticleEffectData.cs
@@ -253,7 +253,7 @@ public class GetParticleEffectData {
             result = (flag && flag2);
         }
 
-        return flag;
+        return result;
     }
 
     static bool AnimationCurveSupportsProcedural(AnimationCurve curve)

--- a/Assets/Tools/Scripts/ParticleEffectCurve.cs
+++ b/Assets/Tools/Scripts/ParticleEffectCurve.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-public class ParticleEffectCurve : MonoBehaviour {
+public class ParticleEffectCurve {
 
     public AnimationCurve animationCurve = new AnimationCurve();
 

--- a/Assets/Tools/Scripts/ParticleEffectCurve.cs
+++ b/Assets/Tools/Scripts/ParticleEffectCurve.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿#if UNITY_EDITOR
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -57,3 +58,4 @@ public class ParticleEffectCurve {
     }
 
 }
+#endif

--- a/Assets/Tools/Scripts/ParticleEffectScript.cs
+++ b/Assets/Tools/Scripts/ParticleEffectScript.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if UNITY_EDITOR
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
@@ -129,3 +130,4 @@ public class ParticleEffectScript : MonoBehaviour {
         };
     }
 }
+#endif

--- a/Assets/Tools/Scripts/ParticleEffectScript.cs
+++ b/Assets/Tools/Scripts/ParticleEffectScript.cs
@@ -44,7 +44,11 @@ public class ParticleEffectScript : MonoBehaviour {
     void Start()
     {
         m_ParticleSystems = GetComponentsInChildren<ParticleSystem>();
+#if UNITY_2017
         m_CalculateEffectUIDataMethod = typeof(ParticleSystem).GetMethod("CalculateEffectUIData", BindingFlags.Instance | BindingFlags.NonPublic);
+#else
+        m_CalculateEffectUIDataMethod = typeof(ParticleSystem).GetMethod("CountSubEmitterParticles", BindingFlags.Instance | BindingFlags.NonPublic);
+#endif
     }
 
     private void LateUpdate()
@@ -68,9 +72,16 @@ public class ParticleEffectScript : MonoBehaviour {
         foreach (var ps in m_ParticleSystems)
         {
             int count = 0;
-            object[] invokeArgs = new object[] { count, 0.0f, Mathf.Infinity };
+#if UNITY_2017
+            object[] invokeArgs = { count, 0.0f, Mathf.Infinity };
             m_CalculateEffectUIDataMethod.Invoke(ps, invokeArgs);
             count = (int)invokeArgs[0];
+#else
+            object[] invokeArgs = { count };
+            m_CalculateEffectUIDataMethod.Invoke(ps, invokeArgs);
+            count = (int)invokeArgs[0];
+            count += ps.particleCount;
+#endif
             m_ParticleCount += count;
         }
         if (m_MaxParticleCount < m_ParticleCount)

--- a/Assets/Tools/Scripts/SingleEffectEvla.cs
+++ b/Assets/Tools/Scripts/SingleEffectEvla.cs
@@ -82,8 +82,6 @@ public class SingleEffectEvla {
         }  
     }
 
-    bool isPlay = false;
-
     public void Simsimulate(float time)
     {
         if (!_effectObj.activeSelf)

--- a/Assets/Tools/Scripts/SingleEffectEvla.cs
+++ b/Assets/Tools/Scripts/SingleEffectEvla.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿#if UNITY_EDITOR
+using System.Collections;
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
@@ -278,3 +279,4 @@ public class SingleEffectEvla {
         _qualityIndex = qualityIndex;
     }
 }
+#endif


### PR DESCRIPTION
## 问题

### 兼容问题

`ProjectSettings/ProjectVersion.txt` 显示的版本号是 Unity 2017.2.2f1，因此在目标版本 Unity 5.6.6f2 上有一些 API 不存在，需要手动加入版本宏定义进行处理。

例如粒子数量是通过反射调用 Unity 2017.2.2f1 中的 `ParticleSystem.CalculateEffectUIData`，需要修改为 Unity 5.6.6f2 的 `ParticleSystem.CountSubEmitterParticles`。

### 获取信息不正确

检查源代码发现获取贴图内存使用的是 `Profiler.GetRuntimeMemorySizeLong` API，在编辑器下显示的是编辑器所在的平台内存占用，而不是目标平台的内存占用。

因此修改为通过反射调用的 Unity 私有 API `UnityEditor.TextureUtil.GetStorageMemorySize`，这是预览窗口中显示目标平台内存大小的 API。

### 打包时有编译错误

因为运行时脚本中存在 `using UnityEditor;` 声明，理论上来说此工具并不需要打包到最终版本中，因此将使用到的运行时脚本使用 `UNITY_EDITOR` 宏定义完全包围，这样就不会影响打包。

## 缺失功能

### ParticleSystem 数量

使用 `GetComponentsInChildren(true)` 获取数组，然后直接打印组件的数量即可。

注意：一定要包含未启用的 ParticleSystem 组件，防止统计有误。

### 贴图 数量

在遍历获取贴图大小时，可以一并将其计数返回。

注意：考虑到特效中使用的不同 ParticleSystem 可能会引用相同的贴图，因此在遍历时必须去除重复。

### 操作优化

实际使用工具时是先添加脚本后再运行的，这样导致 Prefab 上增加了一个无用的脚本。
不过如果未去除 `ParticleEffectScript` 脚本就点击 Prefab 的 Apply 按钮保存则工具会报错。
但是实际上美术在使用工具时偶尔会遗忘，从而导致 Prefab 资源被无用脚本污染。

解决方案是使用播放状态变化事件以及编辑器自身的 Update 事件去检查是否进入到播放状态，决定是否添加测试脚本。

注意：`InitializeOnLoad` 会在播放后重新触发，因此无法通过静态变量的方式保存测试开始的请求状态，因此使用 `EditorPref` 保存请求状态。

## 文章链接

- [Unity 特效性能分析工具 - 狂飙](https://networm.me/2019/07/28/unity-particle-effect-profiler/)

## 其他

有任何需求请直接提出来，比如提交日志如果需要用中文的，那么可以直接改。
